### PR TITLE
Server/single table strategy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # tendenz
+
 Tendenz is an application designed to analyze and present statistical significance in financial instruments. It leverages advanced algorithms to identify trends and shifts in the financial market.
+
+## Dev environment
+
+```sh
+fly proxy 5432 -a tendenz-db
+```
+
+Environment:
+
+```env
+DATABASE_URL="postgres://{username}:{password}@localhost:5432/tendenz_server?connection_limit=5"
+```
+
+- `/tendenz_server` specifies the database of the backend server
+- `connection_limit=5` fixes an issues with high CPU count machines. The default setting sometimes opens more connections then postgres can handle.
+
+```sh
+npx prisma generate
+```

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-config-prettier": "^8.10.0",
         "jest": "^29.6.2",
         "prettier-plugin-organize-imports": "^3.2.3",
-        "prisma": "^5.0.0",
+        "prisma": "^5.1.1",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6"
@@ -1547,9 +1547,9 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
-      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.1.tgz",
+      "integrity": "sha512-NV/4nVNWFZSJCCIA3HIFJbbDKO/NARc9ej0tX5S9k2EVbkrFJC4Xt9b0u4rNZWL4V+F5LAjvta8vzEUw0rw+HA==",
       "devOptional": true,
       "hasInstallScript": true
     },
@@ -5582,13 +5582,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
-      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.1.tgz",
+      "integrity": "sha512-WJFG/U7sMmcc6TjJTTifTfpI6Wjoh55xl4AzopVwAdyK68L9/ogNo8QQ2cxuUjJf/Wa82z/uhyh3wMzvRIBphg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.0.0"
+        "@prisma/engines": "5.1.1"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
     "eslint-config-prettier": "^8.10.0",
     "jest": "^29.6.2",
     "prettier-plugin-organize-imports": "^3.2.3",
-    "prisma": "^5.0.0",
+    "prisma": "^5.1.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -27,6 +27,9 @@ model UsStockDaily {
   logReturn      Float?
 
   @@id([ticker, date])
+  @@index([marketCap], type: BTree)
+  @@index(date(sort: Desc), type: BTree)
+  @@index([sigmaAbs(sort: Desc)], type: BTree)
 }
 
 model UsStocks {

--- a/server/src/dailyRoutine/MarketCapCalculator.ts
+++ b/server/src/dailyRoutine/MarketCapCalculator.ts
@@ -113,7 +113,7 @@ export class MarketCapCalculator {
 			| {
 					ticker: string
 					success: false
-					errorCode: errorCodes
+					errorCode: MarketCapCalcErrorCodes
 			  }
 		)[],
 		dailysLength: number,
@@ -122,7 +122,7 @@ export class MarketCapCalculator {
 		const failResults = results.filter(({ success }) => success === false) as {
 			ticker: string
 			success: false
-			errorCode: errorCodes
+			errorCode: MarketCapCalcErrorCodes
 		}[]
 
 		const groupedByErrorCode = failResults.reduce(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,10 @@ const fastify = Fastify({
 	logger: true,
 })
 
+process.on('SIGINT', async () => await fastify.close()) // CTRL+C
+process.on('SIGQUIT', async () => await fastify.close()) // Keyboard quit
+process.on('SIGTERM', async () => await fastify.close()) // `kill` command
+
 fastify.register(cors, {
 	origin: '*',
 })
@@ -98,7 +102,7 @@ fastify.get('/us-stocks/daily/:page', async request => {
 		}
 	})
 
-	console.log('groupedByTicker :>> ', mergeGrouped)
+	//console.log('groupedByTicker :>> ', mergeGrouped)
 
 	return mergeGrouped
 })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,7 +48,7 @@ fastify.get('/us-stocks/daily/:page', async request => {
 			UsStocks: {
 				name: { not: null },
 			},
-			sigma: { not: null },
+			sigmaAbs: { not: null },
 		},
 		take: PAGE_SIZE,
 		skip,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import Bree from 'bree'
 import Fastify from 'fastify'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { DatabaseApi } from './lib/databaseApi/databaseApi.js'
 import prismaPlugin from './plugins/prisma.js'
 
 if (process.env.NODE_ENV === 'production') {
@@ -20,7 +21,89 @@ fastify.register(cors, {
 
 fastify.register(prismaPlugin)
 
-fastify.get('/:page', async (request, reply) => {
+fastify.get('/us-stocks/daily/:page', async request => {
+	const query = request.query as Query
+	const minMarketCap = Number(query?.minMarketCap) || undefined
+
+	const db = new DatabaseApi(fastify.prisma)
+
+	const PAGE_SIZE = 10
+	const params = request.params as Params
+	const page = Number(params?.page) || 0
+	const skip = page * PAGE_SIZE
+
+	const mostRecentDates = await db.getMostRecentDates(2)
+
+	const dailyGroups = await fastify.prisma.usStockDaily.findMany({
+		orderBy: {
+			sigmaAbs: 'desc',
+		},
+		where: {
+			marketCap: { gte: minMarketCap } || { not: null },
+			date: mostRecentDates[0],
+			UsStocks: {
+				name: { not: null },
+			},
+			sigma: { not: null },
+		},
+		take: PAGE_SIZE,
+		skip,
+		select: {
+			close: true,
+			ticker: true,
+			sigma: true,
+			date: true,
+			marketCap: true,
+			UsStocks: {
+				select: {
+					name: true,
+				},
+			},
+		},
+	})
+
+	const tickers = dailyGroups.map(value => value.ticker)
+
+	const secondLasts = await fastify.prisma.usStockDaily.findMany({
+		where: {
+			date: mostRecentDates[1],
+			ticker: { in: tickers },
+		},
+		select: {
+			close: true,
+			ticker: true,
+			date: true,
+		},
+	})
+
+	const grouped = dailyGroups.map(
+		({ close, date, UsStocks: { name }, ...rest }) => {
+			return {
+				...rest,
+				name,
+				last: {
+					close: close,
+					date: date,
+				},
+			}
+		},
+	)
+
+	const mergeGrouped = secondLasts.map(curr => {
+		const index = grouped.findIndex(value => value.ticker === curr.ticker)
+
+		return {
+			...grouped[index],
+			secondLast: { close: curr.close, date: curr.date },
+		}
+	})
+
+	console.log('groupedByTicker :>> ', mergeGrouped)
+
+	return mergeGrouped
+})
+
+fastify.get('/:page', async request => {
 	const query = request.query as Query
 	const minMarketCap = Number(query?.minMarketCap)
 
@@ -99,9 +182,9 @@ const bree = new Bree({
 })
 
 const start = async () => {
-	bree.start()
+	//bree.start()
 	try {
-		await fastify.listen({ port: 3000, host: '0.0.0.0' })
+		await fastify.listen({ port: 3001, host: '0.0.0.0' })
 	} catch (err) {
 		fastify.log.error(err)
 		process.exit(1)

--- a/server/src/jobs/updateMarket.ts
+++ b/server/src/jobs/updateMarket.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import dotenv, { configDotenv } from 'dotenv'
 import 'dotenv/config'
+import { MarketCapCalculator } from '../dailyRoutine/MarketCapCalculator.js'
 import { SigmaCalculator } from '../dailyRoutine/SigmaCalculator.js'
 import { SplitDetector } from '../dailyRoutine/SplitDetector.js'
 import { dailySigmaRoutine } from '../dailyRoutine/dailySigmaRoutine.js'
@@ -28,6 +29,7 @@ const requestHandler = new PolygonRequestHandler(apiKey)
 const stocksApi = new PolygonStocksApi(requestHandler)
 const splitDetector = new SplitDetector(db, stocksApi)
 const sigmaCalculator = new SigmaCalculator(db)
+const marketCapCalculator = new MarketCapCalculator(db)
 
 try {
 	await reverseIncrementDailyUpdate(db, stocksApi)
@@ -35,6 +37,7 @@ try {
 	await db.clearSigma()
 	await dailySigmaRoutine()
 	await sigmaCalculator.run()
+	await marketCapCalculator.run()
 } catch (e) {
 	console.error(e)
 	process.exit(1)

--- a/server/src/jobs/updateSupplements.ts
+++ b/server/src/jobs/updateSupplements.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { DetailsSupplementer } from '../dailyRoutine/DetailsSupplementer.js'
 import { MarketCapCalculator } from '../dailyRoutine/MarketCapCalculator.js'
+import { supplementTickerDetails } from '../dailyRoutine/supplementTickerDetails.js'
 import { DatabaseApi } from '../lib/databaseApi/databaseApi.js'
 import { PolygonRequestHandler } from '../lib/polygonApi/polygonRequestHandler.js'
 import { PolygonStocksApi } from '../lib/polygonApi/polygonStocksApi.js'
@@ -22,7 +23,7 @@ const detailsSupplementer = new DetailsSupplementer(db, stocksApi)
 const marketCapCalculator = new MarketCapCalculator(db)
 
 try {
-	//await supplementTickerDetails(db, stocksApi)
+	await supplementTickerDetails(db, stocksApi)
 	await detailsSupplementer.run()
 	await marketCapCalculator.run()
 } catch (e) {

--- a/server/src/lib/databaseApi/databaseApi.ts
+++ b/server/src/lib/databaseApi/databaseApi.ts
@@ -167,7 +167,7 @@ export class DatabaseApi {
 	}
 
 	async getMostRecentDate() {
-		const daily = await this.prisma.usStockDaily.findFirst({
+		const daily = await this.prisma.usStockDaily.findFirstOrThrow({
 			orderBy: {
 				date: 'desc',
 			},
@@ -177,11 +177,19 @@ export class DatabaseApi {
 			},
 		})
 
-		if (!daily) {
-			throw new Error('Database empty or inaccessible')
-		}
-
 		return daily.date
+	}
+
+	async getMostRecentDates(daysMinus: number = 1) {
+		const dailys = await this.prisma.usStockDaily.groupBy({
+			by: ['date'],
+			orderBy: { date: 'desc' },
+			take: daysMinus,
+		})
+
+		const dates = dailys.map(daily => daily.date)
+
+		return dates
 	}
 
 	async createSigmaYesterday(data: Prisma.SigmaUsStocksYesterdayCreateInput) {

--- a/server/src/plugins/prisma.ts
+++ b/server/src/plugins/prisma.ts
@@ -14,6 +14,7 @@ const prismaPlugin: FastifyPluginAsync = fp(async (server, options) => {
 	})
 
 	await prisma.$connect()
+	server.log.info('Connecting Prsima to db')
 
 	server.decorate('prisma', prisma)
 

--- a/server/src/plugins/prisma.ts
+++ b/server/src/plugins/prisma.ts
@@ -10,13 +10,18 @@ declare module 'fastify' {
 
 const prismaPlugin: FastifyPluginAsync = fp(async (server, options) => {
 	const prisma = new PrismaClient({
-		log: ['error', 'warn'],
+		log: ['error', 'warn', 
+		// { emit: 'event', level: 'query' }],
 	})
 
 	await prisma.$connect()
 	server.log.info('Connecting Prsima to db')
 
 	server.decorate('prisma', prisma)
+
+	// prisma.$on('query', async e => {
+	// 	server.log.info(`${e.query} ${e.params}`)
+	// })
 
 	server.addHook('onClose', async server => {
 		server.log.info('disconnecting Prisma from DB')

--- a/server/src/plugins/prisma.ts
+++ b/server/src/plugins/prisma.ts
@@ -8,20 +8,22 @@ declare module 'fastify' {
 	}
 }
 
-const prismaPlugin: FastifyPluginAsync = fp(async (server, options) => {
+const prismaPlugin: FastifyPluginAsync = fp(async server => {
 	const prisma = new PrismaClient({
-		log: ['error', 'warn', 
-		// { emit: 'event', level: 'query' }],
+		log: [
+			'error',
+			'warn',
+			// { emit: 'event', level: 'query' }
+		],
 	})
+	// prisma.$on('query', async e => {
+	// 	server.log.info(`${e.query} ${e.params}`)
+	// })
 
 	await prisma.$connect()
 	server.log.info('Connecting Prsima to db')
 
 	server.decorate('prisma', prisma)
-
-	// prisma.$on('query', async e => {
-	// 	server.log.info(`${e.query} ${e.params}`)
-	// })
 
 	server.addHook('onClose', async server => {
 		server.log.info('disconnecting Prisma from DB')

--- a/server/src/tests/SigmaCalculator.test.ts
+++ b/server/src/tests/SigmaCalculator.test.ts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { describe, expect, it, jest } from '@jest/globals'
+import { describe, expect, it } from '@jest/globals'
 import { SigmaCalculator } from '../dailyRoutine/SigmaCalculator.js'
 
 describe('SigmaCalculator', () => {
@@ -21,49 +20,6 @@ describe('SigmaCalculator', () => {
 
 			const result = SigmaCalculator.calculate(dataPoints)
 			expect(result.sigma).toBeCloseTo(-0.8793205529013357)
-			expect(result.stdev).toBeCloseTo(0.010135453070384291)
-			expect(result.mean).toBeCloseTo(0.010135453070384291)
-			expect(result.last.close).toBe(173.59)
-			expect(result.secondLast.close).toBe(173.3)
 		})
-	}),
-		jest.mock('../lib/databaseApi/databaseApi', () => {
-			const originalModule = jest.requireActual(
-				'../lib/databaseApi/databaseApi',
-			)
-
-			return {
-				__esModule: true,
-				...originalModule,
-				functionTwo: jest.fn(() => 'functionTwo mocked implementation'),
-			}
-		})
-	// Tests that the SigmaCalculator class can successfully calculate sigma for all tickers with enough data points
-	it('should calculate sigma for all tickers with enough data points', async () => {
-		const mockDate = new Date()
-		const mockTicker = 'AAPL'
-		const mockName = 'Apple Inc.'
-		const mockClose = 100
-		const dbMock = {
-			getMostRecentDate: jest.fn().mockImplementation(() => mockDate),
-			getTickersWithNameOnDate: jest
-				.fn()
-				.mockImplementation(() => [{ ticker: mockTicker, name: mockName }]),
-			getDailyInDateRange: jest.fn().mockImplementation(() => [
-				{ close: mockClose, date: mockDate },
-				{ close: mockClose + 10, date: mockDate },
-			]),
-			createSigmaYesterday: jest.fn().mockImplementation(() => {}),
-		}
-		const sigmaCalculator = new SigmaCalculator(dbMock)
-		await sigmaCalculator.run()
-		expect(dbMock.getMostRecentDate).toHaveBeenCalled()
-		expect(dbMock.getTickersWithNameOnDate).toHaveBeenCalledWith(mockDate)
-		expect(dbMock.getDailyInDateRange).toHaveBeenCalledWith(
-			mockTicker,
-			expect.anything(),
-			expect.anything(),
-		)
-		expect(dbMock.createSigmaYesterday).toHaveBeenCalled()
 	})
 })

--- a/web/app/lib/api/sharedApi.tsx
+++ b/web/app/lib/api/sharedApi.tsx
@@ -19,4 +19,4 @@ export interface tendenzApiSigmaYesterday {
 }
 
 export const getStocksURL = (page: number, minMarketCap: number) =>
-	`http://0.0.0.0:3001/us-stocks/daily/${page}?minMarketCap=${minMarketCap}`
+	`https://tendenz-server.fly.dev/${page}?minMarketCap=${minMarketCap}`

--- a/web/app/lib/api/sharedApi.tsx
+++ b/web/app/lib/api/sharedApi.tsx
@@ -19,4 +19,4 @@ export interface tendenzApiSigmaYesterday {
 }
 
 export const getStocksURL = (page: number, minMarketCap: number) =>
-	`https://tendenz-server.fly.dev/${page}?minMarketCap=${minMarketCap}`
+	`http://0.0.0.0:3001/us-stocks/daily/${page}?minMarketCap=${minMarketCap}`


### PR DESCRIPTION
- added api (/us-stocks/daily/) to handle new single table backend strategy
- add indexes to db to make new strategy performant
- fixes result priting issues in market cap calculator
- bump prisma
- Running both previous and current sigma strategy in parallel - frontend still using old